### PR TITLE
Relace httpd with WEBrick

### DIFF
--- a/bugzilla-cronjob.yaml
+++ b/bugzilla-cronjob.yaml
@@ -29,7 +29,7 @@ spec:
             args:
               - /bin/bash
               - -c
-              - /usr/bin/bugzilla $SECRET_USERNAME $SECRET_PASSWORD
+              - /usr/bin/bugzilla login $SECRET_USERNAME $SECRET_PASSWORD
             volumeMounts:
               - name: bugzilla-login
                 mountPath: /bugzilla

--- a/shiftzilla-server.yaml
+++ b/shiftzilla-server.yaml
@@ -14,11 +14,16 @@ spec:
     spec:
       containers:
       - name: server
-        image: registry.access.redhat.com/rhscl/httpd-24-rhel7
+        image: docker-registry.default.svc:5000/shiftzilla/shiftzilla
+        args:
+          - /usr/bin/ruby
+          - -run
+          - -e
+          - httpd
+          - /shiftzilla/storage/www
         volumeMounts:
         - name: shiftzilla-files
-          mountPath: /opt/rh/httpd24/root/var/www/html
-          subPath: www
+          mountPath: /shiftzilla/storage
       volumes:
       - name: shiftzilla-files
         persistentVolumeClaim:


### PR DESCRIPTION
Apache httpd started firing up additional threads, which consumed the entire project quota. Switching to extremely basic built-in Ruby web server to keep resource consumption down.