### PR TITLE
Adds pruner cronjob yaml

### DIFF
--- a/pruner-cronjob.yaml
+++ b/pruner-cronjob.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: cleanup
+spec:
+  schedule: "0 3 * * *"
+  concurrencyPolicy: Replace
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: shiftzilla
+            image: docker-registry.default.svc:5000/shiftzilla/shiftzilla
+            args:
+              - /bin/bash
+              - -c
+              - "sqlite3 shiftzilla.sqlite -echo \"DELETE FROM ALL_BUGS WHERE Snapshot < date('now','localtime','-180 days');VACUUM;\""
+            volumeMounts:
+              - name: shiftzilla-storage
+                mountPath: /shiftzilla/storage
+          restartPolicy: OnFailure
+          volumes:
+            - name: shiftzilla-storage
+              persistentVolumeClaim:
+                claimName: shiftzilla-state


### PR DESCRIPTION
Adds a pruner cronjob to keep the database in check.

Runs daily (in shiftzilla's "off" hours) and removes rows that are over 180 days old.

Note - I've tested the individual commands locally and on upshift.  I haven't managed to setup shiftzilla completely on a local openshift cluster to test out the full pruner cronjob.