### PR TITLE
Update for cluster migration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,5 @@ RUN pip install python-bugzilla
 RUN gem install shiftzilla
 
 # Remove build tools
-RUN dnf remove -y ruby-devel gcc-c++ make sqlite-devel
+# Commenting out because this now removes python2
+#RUN dnf remove -y ruby-devel gcc-c++ make sqlite-devel

--- a/cleanup-cronjob.yaml
+++ b/cleanup-cronjob.yaml
@@ -19,6 +19,7 @@ spec:
             volumeMounts:
               - name: shiftzilla-storage
                 mountPath: /shiftzilla/storage
+                readOnly: false
           restartPolicy: OnFailure
           volumes:
             - name: shiftzilla-storage

--- a/shiftzilla-cronjob.yaml
+++ b/shiftzilla-cronjob.yaml
@@ -26,6 +26,7 @@ spec:
                 mountPath: /bugzilla
               - name: shiftzilla-storage
                 mountPath: /shiftzilla/storage
+                readOnly: false
               - name: shiftzilla-cfg
                 mountPath: /shiftzilla/config
           restartPolicy: OnFailure

--- a/shiftzilla-server.yaml
+++ b/shiftzilla-server.yaml
@@ -47,8 +47,8 @@ spec:
         - name: shiftzilla-files
           mountPath: /opt/rh/httpd24/root/var/www/html
           subPath: www
+          readOnly: true
       volumes:
       - name: shiftzilla-files
         persistentVolumeClaim:
-          claimName: shiftzilla-state
-
+          claimName: bugzilla-state

--- a/shiftzilla-state-pvc.yaml
+++ b/shiftzilla-state-pvc.yaml
@@ -8,7 +8,8 @@ metadata:
   name: shiftzilla-state
 spec:
   accessModes:
-  - ReadWriteMany
+  - ReadWriteOnce
   resources:
     requests:
       storage: 2Gi
+  storageClassName: ceph-dyn-common-nvme

--- a/tester-pod.yaml
+++ b/tester-pod.yaml
@@ -15,6 +15,7 @@ spec:
       mountPath: /bugzilla-state
     - name: sz-stuff
       mountPath: /shiftzilla-state
+      readOnly: false
   volumes:
   - name: bz-stuff
     persistentVolumeClaim:


### PR DESCRIPTION
As part of a cluster migration, we needed to change a number of things.

The fedora build was removing python2 as part of our cleanup process.
Commenting out the uninstall line in the Dockerfile for now - in the future
the build will be slightly more efficient if we determine what python2 depends
on and still cleaning up the other things.

We were using gluster for our persistent storage previously.  That is no longer
an option.  We've switched to cephRBD, which doesn't support ReadWriteMany.  So
the shiftzilla website will now be placed on the bugzilla-state pvc which is
ReadWriteMany. The database will remain on the cephRBD shiftzilla-state pvc,
which will only be accessed by a single pod at a time (build, cleanup, backup).
