### PR TITLE
Switch to nfs PVC

### DIFF
--- a/cleanup-cronjob.yaml
+++ b/cleanup-cronjob.yaml
@@ -24,4 +24,4 @@ spec:
           volumes:
             - name: shiftzilla-storage
               persistentVolumeClaim:
-                claimName: shiftzilla-state
+                claimName: shiftzilla-state-nfs

--- a/shiftzilla-cronjob.yaml
+++ b/shiftzilla-cronjob.yaml
@@ -36,7 +36,7 @@ spec:
                 claimName: bugzilla-state
             - name: shiftzilla-storage
               persistentVolumeClaim:
-                claimName: shiftzilla-state
+                claimName: shiftzilla-state-nfs
             - name: shiftzilla-cfg
               configMap:
                 name: shiftzilla-config


### PR DESCRIPTION
As part of the upshift -> psi migration, we needed to switch to a new external
static NFS volume. To avoid name conflicts, this was added as
`shiftzilla-state-nfs`.  Updates the cronjobs that access the databse to mount
the new volume.